### PR TITLE
Dont seek past today in catchup

### DIFF
--- a/awn_controller.py
+++ b/awn_controller.py
@@ -23,7 +23,7 @@ Functions:
 Helper Functions:
 - validate_archive: Ensure archive is non-empty and valid.
 - fetch_device_data: Page data from AWN from a starting point.
-- validate_new_data: Sanity check newly fetched data.
+- is_fresh_data: Check if new data is structurally sound and non-overlapping.
 - combine_interim_data: Accumulate paged results.
 - update_last_date: Move forward in time for next fetch.
 - log_interim_progress: Log fetch progress in paged loop.
@@ -223,10 +223,8 @@ def get_history_since_last_archive(
             continue
 
         # Check if the new data is valid and advances the timeline
-        is_valid, last_date_candidate = validate_new_data(
-            new_data, interim_df, gap_attempts, last_date, limit
-        )
-        if not is_valid:
+        is_fresh = is_fresh_data(new_data, interim_df)
+        if not is_fresh:
             last_date, gap_attempts, exit_flag = seek_over_time_gap(
                 last_date, gap_attempts, limit
             )
@@ -267,7 +265,7 @@ def fetch_device_data(device, last_date, limit):
         return pd.DataFrame(), False
 
 
-def validate_new_data(
+def is_fresh_data(
     new_data: pd.DataFrame,
     interim_df: pd.DataFrame,
 ) -> bool:

--- a/awn_controller.py
+++ b/awn_controller.py
@@ -270,29 +270,23 @@ def fetch_device_data(device, last_date, limit):
 def validate_new_data(
     new_data: pd.DataFrame,
     interim_df: pd.DataFrame,
-    gap_attempts: int,
-    last_date: datetime,
-    limit: int,
-) -> tuple[bool, datetime]:
+) -> bool:
     """
-    Validate new data fetched for completeness and freshness.
+    Validates the new data is structurally complete and non-overlapping.
 
     :param new_data: Newly fetched DataFrame.
-    :param interim_df: Current interim DataFrame of accumulated data.
-    :param gap_attempts: Number of consecutive fetches that failed to advance time.
-    :param last_date: The most recent timestamp seen so far.
-    :param limit: Number of records per fetch.
-    :return: Tuple of (is_valid: bool, new_last_date: datetime).
+    :param interim_df: Accumulated interim data.
+    :return: True if data is fresh and non-duplicate; False otherwise.
     """
     if "dateutc" not in new_data.columns:
         logger.error("New data is missing 'dateutc'.")
-        return False, last_date
+        return False
 
     if not _is_data_new(interim_df, new_data):
-        next_start = _calculate_next_start_date(last_date, gap_attempts + 1, limit)
-        return False, next_start
+        logger.debug("Fetched data is not new or overlaps with interim.")
+        return False
 
-    return True, last_date
+    return True
 
 
 def combine_interim_data(interim_df, new_data):


### PR DESCRIPTION
## ✨ Improve Seek-Ahead Logic and Data Freshness Validation

### Summary

This PR introduces the following improvements to AWN history fetching:

- 🧠 **Refactored `validate_new_data()` → `is_fresh_data()`**  
  - Now solely responsible for checking schema completeness and data freshness  
  - No longer entangled with time advancement logic (`_calculate_next_start_date`)

- 🧭 **Introduced `seek_over_time_gap()` helper**  
  - Centralizes time gap advancement and retry control  
  - Improves clarity and maintainability

- ⏳ **Prevents fetching into the future**  
  - Adds guard condition to avoid invalid future timestamp queries

- 📓 **Inline comments and function-level docstrings**  
  - Improves readability for paged fetch loop and condition branches

### Rationale

- Simplifies control flow in `get_history_since_last_archive()`
- Keeps validation and seeking responsibilities cleanly separated
- Avoids redundant or unnecessary requests that hit future timestamps
- Enhances logging and structure ahead of future modularization

### Follow-ups

- Consider renaming `_is_data_new()` for improved intent clarity
- Possibly extract fetch loop into its own handler in future