### PR TITLE
fix(deps): add missing pytz dependency

### DIFF
--- a/lookout/core/solar_energy_periods.py
+++ b/lookout/core/solar_energy_periods.py
@@ -4,7 +4,6 @@ Converts raw solar radiation measurements into 15-minute energy periods.
 """
 
 import pandas as pd
-import pytz
 import streamlit as st
 from typing import Dict
 from lookout.core.solar_analysis import LOCATION

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ numpy
 streamlit
 plotly
 python-dateutil
+pytz
 boto3==1.34.99
 botocore<1.35.0
 colour


### PR DESCRIPTION
## Summary
- Streamlit Cloud deploy was crashing on startup with `ModuleNotFoundError: No module named 'pytz'`
- `pytz` is used by `lookout/core/solar_tiles.py:174` but was missing from `requirements.txt`
- Also removes an unused `pytz` import from `lookout/core/solar_energy_periods.py`

## Test plan
- [ ] Streamlit Cloud redeploys successfully after merge
- [ ] App loads without ModuleNotFoundError
- [ ] Solar tabs (which use solar_tiles / solar_energy_periods) render normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)