### PR TITLE
release: add missing pytz dependency

### DIFF
--- a/lookout/core/solar_energy_periods.py
+++ b/lookout/core/solar_energy_periods.py
@@ -4,7 +4,6 @@ Converts raw solar radiation measurements into 15-minute energy periods.
 """
 
 import pandas as pd
-import pytz
 import streamlit as st
 from typing import Dict
 from lookout.core.solar_analysis import LOCATION

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ numpy
 streamlit
 plotly
 python-dateutil
+pytz
 boto3==1.34.99
 botocore<1.35.0
 colour


### PR DESCRIPTION
## Summary
- Promotes the pytz dependency fix from `main` to `live` to restore the Streamlit Cloud deploy
- Adds `pytz` to `requirements.txt` (was imported in `lookout/core/solar_tiles.py` but missing from deps)
- Removes an unused `pytz` import from `lookout/core/solar_energy_periods.py`

## Test plan
- [ ] Streamlit Cloud redeploys on `live` without `ModuleNotFoundError: No module named 'pytz'`
- [ ] App loads
- [ ] Solar tabs render

🤖 Generated with [Claude Code](https://claude.com/claude-code)