### PR TITLE
hotfix(deps): pin pandas<3 until we audit pandas 3.0 compat

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-pandas
+pandas<3
 numpy
 streamlit
 plotly


### PR DESCRIPTION
## Summary
- Streamlit Cloud's `uv` resolver picked up **pandas 3.0.2**, breaking the deployed app.
- Cloud logs show `dateutc` reads back with corrupted values (`sample=[1776665, ...]` instead of 13-digit ms), all 320k archive rows get dropped by the 2020-01-01 guard, rain events detect zero new events, and the energy catalog fails with a `.dt` accessor error.
- Local env runs pandas 2.3.3 and works cleanly. `requirements.txt` had `pandas` unpinned, so this is the minimum pin needed to restore production.
- Proper pandas-3.0 compatibility audit will follow as a separate branch.

## Test plan
- [ ] Merge and let Streamlit Cloud redeploy
- [ ] Boot log shows `pandas==2.x.x` (not 3.x)
- [ ] `Full History Range: (23-02-16 ...) - (26-04-20 ...)` — real dates, not 1970
- [ ] No `rain heatmap guard: dropped 320115 of 320115 row(s)` warning
- [ ] No `Failed to load energy catalog: Can only use .dt accessor` warning
- [ ] Rain, Rain Events, Solar tabs render current data on live URL
