### PR TITLE
chore(repo): ignore .journal worktree

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .streamlit/secrets.toml
 worktrees/
 data/
+.journal


### PR DESCRIPTION
## Summary
- Adds `.journal` to `.gitignore` so the journal skill's orphan worktree isn't tracked on working branches.

## Test plan
- [ ] `.journal/` stays untracked in `git status` on `main` and feature branches
