### PR TITLE
chore(config): ignore direnv files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,7 @@ data/
 .journal
 .scratch/
 ${CLAUDE_PROJECT_DIR}/
+
+# direnv
+.envrc
+.direnv/


### PR DESCRIPTION
## Summary
- Adds `.envrc` and `.direnv/` to `.gitignore` so local conda auto-activation (direnv → `conda activate lookout-new`) stays untracked
- Env name is host-specific, so `.envrc` is intentionally not committed

## Test plan
- [x] `direnv allow` + fresh shell `cd` into repo auto-activates `lookout-new`
- [x] `.envrc` / `.direnv/` no longer show in `git status`
